### PR TITLE
Add support for overlay triplets

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,29 @@ dev-dependencies = ["sdl2-image"]
 x86_64-apple-darwin = { dev-dependencies = ["sdl2-gfx" ] }
 ```
 
+## Overlay triplets
+
+Setting the `overlay-triplets-path` key allows you use custom [triplet files] in
+your build. The value of this key should be the path to a directory containing
+triplet files. These files will be made available during the vcpkg build through
+its `--overlay-triplets` argument.
+
+[triplet files]: https://vcpkg.readthedocs.io/en/latest/users/triplets/
+
+```toml
+[package.metadata.vcpkg]
+git = "https://github.com/microsoft/vcpkg"
+rev = "4c1db68"
+dependencies = ["sdl2"]
+overlay-triplets-path = "support/custom-triplets"
+
+[package.metadata.vcpkg.target]
+x86_64-pc-windows-msvc = { triplet = "x64-windows-static-release" }
+```
+
+Here, the repository should contain a file named
+`support/custom-triplets/x64-windows-static-release.cmake`.
+
 ## Installation
 
 Install by running

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,7 @@ struct Vcpkg {
     overlay_triplets_path: Option<String>,
 
     // Was this ever used??
+    #[allow(dead_code)]
     build_type: Option<String>,
 }
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
This helps with #4.

I also silenced a warning as a conservative way to make it go away — it refers to a field in a Serde struct so if we just get rid of it, that could conceivably break existing files.

Finally I also grouped the return values from the `process_metadata()` function into a struct since the tuple was getting unwieldy.